### PR TITLE
Pin KiCAD container image to version 8.0.7 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}-latest
     container:
-      image: kicad/kicad:8.0
+      image: kicad/kicad:8.0.7
       options: --user root
     steps:
       - name: 💾 Check out repository


### PR DESCRIPTION
This can be removed once the fix for
https://gitlab.com/kicad/code/kicad/-/issues/19521 is released.